### PR TITLE
Don't build conf schema that requires ddsconf (wrong arch in case of crossbuild)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -14,7 +14,8 @@ fn main() {
     dir_builder.create(&cyclonedds_dir).unwrap();
     let cyclonedds = cmake::Config::new("cyclonedds")
         .define("BUILD_SHARED_LIBS", "OFF")
-        .define("BUILD_IDLC", "NO")
+        .define("BUILD_IDLC", "OFF")
+        .define("BUILD_SCHEMA", "OFF")
         .define("ENABLE_SSL", "NO")
         .define("CMAKE_INSTALL_LIBDIR", "lib")
         .out_dir(cyclonedds_dir)


### PR DESCRIPTION
Crossbuilds are currently failing with such error:
```bash
  [ 99%] Linking C executable ../../../bin/ddsconf
  [ 99%] Built target ddsconf
  [100%] Generating cyclonedds.rnc, cyclonedds.xsd, manual/options.md

  /bin/sh: 1: ../bin/ddsconf: Exec format error
  make[2]: *** [docs/CMakeFiles/schema.dir/build.make:75: docs/cyclonedds.rnc] Error 2
  make[1]: *** [CMakeFiles/Makefile2:373: docs/CMakeFiles/schema.dir/all] Error 2
  make: *** [Makefile:156: all] Error 2
  thread 'main' panicked at '
  command did not execute successfully, got: exit status: 2
```

To build the XSD and options description, the build is using the generated `ddsconf` tool.
But in case of crossbuild, `ddsconf` has not the same architecture than the host.

As we don't need to generate those files for cyclors, we can desactivate this step adding `BUILD_SCHEMA=OFF` option to CMake.