### PR TITLE
Disable LTO (Link Time Optimization) building CycloneDDS

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -16,6 +16,7 @@ fn main() {
         .define("BUILD_SHARED_LIBS", "OFF")
         .define("BUILD_IDLC", "OFF")
         .define("BUILD_DDSPERF", "OFF")
+        .define("ENABLE_LTO", "NO")
         .define("ENABLE_SSL", "NO")
         .define("ENABLE_SECURITY", "NO")
         .define("CMAKE_INSTALL_LIBDIR", "lib")


### PR DESCRIPTION
As reported in eclipse-zenoh/zenoh-plugin-dds#101 the `-flto -fno-fat-lto-objects` used by CycloneDDS 0.10.2 build makes it static library to fail to be linked by Rust.
This PR deactivates those flags configuring CycloneDDS CMake with `ENABLE_LTO=no`.