### PR TITLE
Fix Iceoryx build issues.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -247,6 +247,7 @@ fn build_cyclonedds(src_dir: &Path, out_dir: &Path, iceoryx_path: &OsStr) -> Pat
     if !iceoryx_path.is_empty() {
         cyclonedds = cyclonedds
             .env("iceoryx_hoofs_DIR", iceoryx_path)
+            .env("iceoryx_platform_DIR", iceoryx_path)
             .env("iceoryx_posh_DIR", iceoryx_path)
             .define("ENABLE_ICEORYX", "YES");
     } else {


### PR DESCRIPTION
## Changes

- Pass `iceoryx_platform_DIR` to CycloneDDS during CMake configuration. Newer Iceoryx versions expose `iceoryx_platform` as a separate package, which CycloneDDS could not previously locate.
- Update the Iceoryx submodule from v2.95.4 to v2.95.8. This includes an upstream fix for a comparator incompatible with newer macOS libc++ versions.