### PR TITLE
fix: disable Iceoryx TOML config for bundled build

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -205,6 +205,9 @@ fn build_iceoryx(src_dir: &Path, out_dir: &Path) -> PathBuf {
 
     let iceoryx_path = iceoryx
         .define("BUILD_SHARED_LIBS", "OFF")
+        // Cyclors only links Iceoryx libraries; it does not build/use the bundled
+        // RouDi daemon or TOML configuration, so disabling it avoids obsolete cpptoml.
+        .define("TOML_CONFIG", "OFF")
         .out_dir(out_dir)
         .build();
 


### PR DESCRIPTION
Cyclors only links the Iceoryx libraries needed by Cyclone DDS (iceoryx_hoofs, iceoryx_posh, and iceoryx_platform). It does not link iceoryx_posh_config or use the bundled iox-roudi executable.

Disable Iceoryx TOML_CONFIG in the bundled build so the obsolete cpptoml CMake project is not downloaded/configured. This keeps the Cyclone DDS shared-memory path working with CMake 4 without pinning CMake or patching Cargo registry sources.

Consequences of this change:

- Cyclors' bundled Iceoryx build remains suitable for Cyclone DDS shared-memory support.
- Cyclors should not be treated as a provider of a bundled iox-roudi daemon with TOML configuration support.
- Users/downstream projects that need iox-roudi, especially TOML-configured RouDi, must build or install RouDi separately from Iceoryx.
- Downstream docs that currently point users at target/.../build/cyclors-*/out/iceoryx-build/bin/iox-roudi should be updated.

Validation performed locally with CMake 4.2.3:

- cargo build --features iceoryx --verbose
- cargo test --features iceoryx --verbose
- downstream smoke: cargo build -p zenoh-plugin-dds --features dds_shm --verbose --config 'patch.crates-io.cyclors.path="/tmp/cyclors-cmake4-fix"'

The generated CMake invocation contains -DTOML_CONFIG=OFF; no cpptoml CMake build/download directory is generated. Iceoryx still installs its bundled cpptoml license text under documentation paths.